### PR TITLE
Added SPARQL query for books

### DIFF
--- a/know/rdf/queries/wikidata/get_book.sparql
+++ b/know/rdf/queries/wikidata/get_book.sparql
@@ -1,0 +1,10 @@
+# Replace $0 with book entry 
+SELECT ?title ?author ?authorLabel ?genre ?genreLabel ?published
+WHERE
+{
+  wd:$0 wdt:P1476 ?title;
+             wdt:P50 ?author;
+             wdt:P136 ?genre;
+             wdt:P577 ?published.
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE]". }
+}


### PR DESCRIPTION
## Description

Adding a SPARQL query for books
## How to test

Replace the $0 sign for a book wikidata entry. For example, replace $0 with Q190192 (entry of Dune).

## Related tasks

Closes #22 